### PR TITLE
Add dynamic `sitemap.xml` (+ fix event detail page)

### DIFF
--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
-from flask import Blueprint, abort, current_app, flash, g, redirect, render_template, request, session, url_for
+from flask import Blueprint, Response, abort, current_app, flash, g, redirect, render_template, request, session, url_for
 
 from forms import AccessibilityForm, CollaboratorRequestForm
 from sqlalchemy.orm import joinedload
@@ -150,6 +150,31 @@ def accessibility_form(token):
 def venue_accessibility(venue_id):
     venue = Venue.query.get_or_404(venue_id)
     return render_template('venue_accessibility.html', venue=venue, info=venue.accessibility)
+
+
+@bp.route('/sitemap.xml')
+def sitemap():
+    pages = [
+        (url_for('public.calendar_view', _external=True), 'daily'),
+        (url_for('public.about', _external=True), 'monthly'),
+    ]
+    for lang in SUPPORTED_LOCALES:
+        pages.append((url_for('public.impressum', lang=lang, _external=True), 'yearly'))
+        pages.append((url_for('public.agb', lang=lang, _external=True), 'yearly'))
+        pages.append((url_for('public.datenschutz', lang=lang, _external=True), 'yearly'))
+
+    events = Event.query.order_by(Event.date.asc()).all()
+    for event in events:
+        pages.append((url_for('submissions.event_page', event_id=event.id, _external=True), 'weekly'))
+
+    venues = Venue.query.filter(Venue.id.in_(
+        db.session.query(VenueAccessibility.venue_id)
+    )).order_by(Venue.id.asc()).all()
+    for venue in venues:
+        pages.append((url_for('public.venue_accessibility', venue_id=venue.id, _external=True), 'monthly'))
+
+    xml = render_template('sitemap.xml', pages=pages)
+    return Response(xml, mimetype='application/xml')
 
 
 @bp.route('/set-language/<lang>')

--- a/blueprints/submissions.py
+++ b/blueprints/submissions.py
@@ -274,4 +274,4 @@ def submit_event_link():
 @bp.route('/events/<int:event_id>/')
 def event_page(event_id):
     event = Event.query.get_or_404(event_id)
-    return render_template('')
+    return render_template("event_page.html", event=event)

--- a/templates/event_page.html
+++ b/templates/event_page.html
@@ -1,0 +1,115 @@
+{% extends 'base_public.html' %}
+
+{% set display_name = event.name or event.acts or _('Event') %}
+{% set ticket_is_safe = event.ticket_link and (event.ticket_link.startswith('http://') or event.ticket_link.startswith('https://')) %}
+
+{% block title %}{{ display_name }} · diytracker.ch{% endblock %}
+{% block meta_description %}{{ display_name }} — {{ event.venue.name }}, {{ event.venue.city }} · {{ event.date.strftime('%d.%m.%Y') }}{% endblock %}
+
+{% block head_extra %}
+  {% set ld = {
+    "@context": "https://schema.org",
+    "@type": "MusicEvent",
+    "name": display_name,
+    "startDate": event.date.strftime('%Y-%m-%dT%H:%M'),
+    "eventStatus": "https://schema.org/EventScheduled",
+    "url": url_for('submissions.event_page', event_id=event.id, _external=True),
+    "location": {
+      "@type": "Place",
+      "name": event.venue.name,
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": event.venue.address or "",
+        "addressLocality": event.venue.city or "",
+        "addressRegion": event.venue.canton or "",
+        "postalCode": event.venue.plz or "",
+        "addressCountry": "CH"
+      }
+    }
+  } %}
+  {% if event.end_date %}{% set ld = dict(ld, endDate=event.end_date.strftime('%Y-%m-%d')) %}{% endif %}
+  {% if event.flyer %}{% set ld = dict(ld, image=url_for('static', filename=event.flyer, _external=True)) %}{% endif %}
+  {% if event.ticket_link or event.ticket_price %}
+    {% set ld = dict(ld, offers={"@type": "Offer", "url": event.ticket_link if ticket_is_safe else "", "price": event.ticket_price or "", "priceCurrency": "CHF"}) %}
+  {% endif %}
+  <script type="application/ld+json">{{ ld|tojson }}</script>
+{% endblock %}
+
+{% block content %}
+<div class="max-w-2xl mx-auto px-4 py-10">
+
+  <header class="mb-8">
+    <p class="text-xs uppercase tracking-widest text-smudge mb-1">
+      {% if event.is_festival %}{{ _('Festival') }}{% else %}{{ _('Event') }}{% endif %}
+    </p>
+    <h1 class="font-richEatin text-4xl mis-reg leading-none mb-2">{{ display_name }}</h1>
+    {% if event.name and event.acts %}
+    <p class="text-sm text-smudge">{{ event.acts }}</p>
+    {% endif %}
+  </header>
+
+  {% if event.flyer %}
+  <img src="{{ url_for('static', filename=event.flyer) }}" alt="{{ display_name }}"
+       class="w-full max-w-md mb-8 border-2 border-ink" loading="lazy">
+  {% endif %}
+
+  <div class="space-y-2 text-sm">
+    <p>
+      <span class="text-smudge uppercase tracking-wider text-xs">{{ _('Date') }}</span>
+      {{ event.date.strftime('%A, %d.%m.%Y') }}
+      {% if event.end_date %}– {{ event.end_date.strftime('%d.%m.%Y') }}{% endif %}
+      <span class="text-ink/40">·</span> {{ event.doors.strftime('%H:%M') }}
+    </p>
+    <p>
+      <span class="text-smudge uppercase tracking-wider text-xs">{{ _('Venue') }}</span>
+      {{ event.venue.name }}
+    </p>
+    {% if event.venue.address %}
+    <p>
+      <span class="text-smudge uppercase tracking-wider text-xs">{{ _('Address') }}</span>
+      {{ event.venue.address }}
+    </p>
+    {% endif %}
+    <p>
+      <span class="text-smudge uppercase tracking-wider text-xs">{{ _('Location') }}</span>
+      {{ event.venue.plz }} {{ event.venue.city }}{% if event.venue.canton %}, {{ event.venue.canton }}{% endif %}
+    </p>
+    {% if event.genre %}
+    <p>
+      <span class="text-smudge uppercase tracking-wider text-xs">{{ _('Genre') }}</span>
+      {{ event.genre }}
+    </p>
+    {% endif %}
+    {% if event.ticket_price %}
+    <p>
+      <span class="text-smudge uppercase tracking-wider text-xs">{{ _('Price') }}</span>
+      {{ event.ticket_price }}
+    </p>
+    {% endif %}
+    {% if ticket_is_safe %}
+    <p>
+      <span class="text-smudge uppercase tracking-wider text-xs">{{ _('Tickets') }}</span>
+      <a href="{{ event.ticket_link }}" target="_blank" rel="noopener"
+         class="text-bleed underline break-all">{{ event.ticket_link }}</a>
+    </p>
+    {% endif %}
+  </div>
+
+  {% if event.description %}
+  <h2 class="text-xs uppercase tracking-widest font-bold border-b-2 border-ink pb-1 mb-2 mt-8">{{ _('Description') }}</h2>
+  <p class="text-sm whitespace-pre-line">{{ event.description }}</p>
+  {% endif %}
+
+  {% if event.venue.accessibility %}
+  <div class="mt-8">
+    <a href="{{ url_for('public.venue_accessibility', venue_id=event.venue.id) }}"
+       class="text-xs uppercase tracking-widest text-bleed hover:underline">{{ _('Accessibility information') }} →</a>
+  </div>
+  {% endif %}
+
+  <div class="mt-10 pt-6 border-t-2 border-ink">
+    <a href="{{ url_for('public.calendar_view') }}"
+       class="text-xs uppercase tracking-widest text-bleed hover:underline">← {{ _('Back to calendar') }}</a>
+  </div>
+</div>
+{% endblock %}

--- a/templates/sitemap.xml
+++ b/templates/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{%- for loc, changefreq in pages %}
+  <url>
+    <loc>{{ loc }}</loc>
+    <changefreq>{{ changefreq }}</changefreq>
+  </url>
+{%- endfor %}
+</urlset>


### PR DESCRIPTION
diytracker has no sitemap, so search engines (and friendly aggregators 😉) can't discover event pages. This adds a standards-compliant `/sitemap.xml` generated from the DB.

While wiring it up I noticed `/events/<id>` returned `render_template("")` and 500s on every request – since the sitemap links to those pages, this fixes them too: a proper detail template plus JSON-LD `MusicEvent` structured data for rich results.

– a friendly hello from the metalgigs.ch maintainer, whose sitemap you've been enjoying. Now you've got one too. 🤝